### PR TITLE
hotfix: add matplotlib to hf space requirements

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -23,7 +23,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import gradio as gr
 import matplotlib
@@ -31,9 +31,7 @@ import pandas as pd
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
-
-if TYPE_CHECKING:
-    from matplotlib.figure import Figure
+from matplotlib.figure import Figure  # noqa: E402, TC002
 
 # ---------------------------------------------------------------------------
 # path setup: ensure src/ is importable

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -7,6 +7,7 @@ numpy>=1.24.0
 pandas>=2.0.0
 scipy>=1.10.0
 torch>=2.0.0
+matplotlib>=3.7.0
 tabulate>=0.9.0
 pyyaml>=6.0
 omegaconf>=2.3.0


### PR DESCRIPTION
## Summary
- add \`matplotlib>=3.7.0\` to \`src/app/requirements.txt\` so the hugging face space can import the plotting stack at startup
- fixes crash at \`app.py:29 import matplotlib\` → \`ModuleNotFoundError\`

closes #67

## Context
the demo at https://ishrith-gowda-memsad-demo.hf.space/ (shared in an internship application) was returning HTTP 503 with hf stage \`RUNTIME_ERROR\`. root cause: matplotlib is imported at module top level for rendering retrieval / anomaly-score plots, but was not declared in the space requirements. hotfix has been deployed directly to the space repo; this PR syncs the change back to main.

## Test plan
- [x] hf space redeploy triggered with updated \`requirements.txt\` (stage now \`BUILDING\`)
- [ ] after build completes: \`curl -sI https://ishrith-gowda-memsad-demo.hf.space/\` returns 200
- [ ] hf api \`runtime.stage\` becomes \`RUNNING\`
- [ ] ci: lint / typecheck / test / security / codeql all green